### PR TITLE
Build fixes: cross-compilation, uClibc and musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # $Id$
 
 DESTDIR=
-PREFIX=/usr/local
+PREFIX?=/usr/local
 ETCDIR=/etc/vpnc
 BINDIR=$(PREFIX)/bin
 SBINDIR=$(PREFIX)/sbin

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,14 @@ BINSRCS = $(addsuffix .c,$(BINS))
 VERSION ?= $(shell sh mk-version)
 RELEASE_VERSION := $(shell cat VERSION)
 
+LIBGCRYPT_CONFIG ?= libgcrypt-config
 CC ?= gcc
 CFLAGS ?= -O3 -g
 override CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
-override CFLAGS +=  $(shell libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
+override CFLAGS +=  $(shell $(LIBGCRYPT_CONFIG) --cflags) $(CRYPTO_CFLAGS)
 override CPPFLAGS += -DVERSION=\"$(VERSION)\"
 LDFLAGS ?= -g
-LIBS += $(shell libgcrypt-config --libs) $(CRYPTO_LDADD)
+LIBS += $(shell $(LIBGCRYPT_CONFIG) --libs) $(CRYPTO_LDADD)
 
 ifeq ($(shell uname -s), SunOS)
 LIBS += -lnsl -lresolv -lsocket

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ RELEASE_VERSION := $(shell cat VERSION)
 
 CC ?= gcc
 CFLAGS ?= -O3 -g
-CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
-CFLAGS +=  $(shell libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
-CPPFLAGS += -DVERSION=\"$(VERSION)\"
+override CFLAGS += -W -Wall -Wmissing-declarations -Wwrite-strings
+override CFLAGS +=  $(shell libgcrypt-config --cflags) $(CRYPTO_CFLAGS)
+override CPPFLAGS += -DVERSION=\"$(VERSION)\"
 LDFLAGS ?= -g
 LIBS += $(shell libgcrypt-config --libs) $(CRYPTO_LDADD)
 
@@ -73,7 +73,7 @@ LIBS += -lnsl -lresolv -lsocket
 endif
 ifneq (,$(findstring Apple,$(shell $(CC) --version)))
 # enabled in FSF GCC, disabled by default in Apple GCC
-CFLAGS += -fstrict-aliasing -freorder-blocks -fsched-interblock
+override CFLAGS += -fstrict-aliasing -freorder-blocks -fsched-interblock
 endif
 
 all : $(BINS) vpnc.8

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ OBJS = $(addsuffix .o,$(basename $(SRCS)))
 CRYPTO_OBJS = $(addsuffix .o,$(basename $(CRYPTO_SRCS)))
 BINOBJS = $(addsuffix .o,$(BINS))
 BINSRCS = $(addsuffix .c,$(BINS))
-VERSION := $(shell sh mk-version)
+VERSION ?= $(shell sh mk-version)
 RELEASE_VERSION := $(shell cat VERSION)
 
 CC ?= gcc

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ endif
 SRCS = sysdep.c vpnc-debug.c isakmp-pkt.c tunip.c config.c dh.c math_group.c supp.c decrypt-utils.c crypto.c $(CRYPTO_SRCS)
 BINS = vpnc cisco-decrypt test-crypto
 OBJS = $(addsuffix .o,$(basename $(SRCS)))
+MANS ?= vpnc.8
 CRYPTO_OBJS = $(addsuffix .o,$(basename $(CRYPTO_SRCS)))
 BINOBJS = $(addsuffix .o,$(BINS))
 BINSRCS = $(addsuffix .c,$(BINS))
@@ -76,7 +77,7 @@ ifneq (,$(findstring Apple,$(shell $(CC) --version)))
 override CFLAGS += -fstrict-aliasing -freorder-blocks -fsched-interblock
 endif
 
-all : $(BINS) vpnc.8
+all : $(BINS) $(MANS)
 
 vpnc : $(OBJS) vpnc.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
@@ -136,7 +137,9 @@ install-common: all
 	install -m600 vpnc.conf $(DESTDIR)$(ETCDIR)/default.conf
 	install -m755 vpnc-disconnect $(DESTDIR)$(SBINDIR)
 	install -m755 pcf2vpnc $(DESTDIR)$(BINDIR)
+ifneq ($(MANS),)
 	install -m644 vpnc.8 $(DESTDIR)$(MANDIR)/man8
+endif
 	install -m644 pcf2vpnc.1 $(DESTDIR)$(MANDIR)/man1
 	install -m644 cisco-decrypt.1 $(DESTDIR)$(MANDIR)/man1
 	install -m644 COPYING $(DESTDIR)$(DOCDIR)

--- a/config.c
+++ b/config.c
@@ -657,8 +657,7 @@ static const struct config_names_s {
 static char *get_config_filename(const char *name, int add_dot_conf)
 {
 	char *realname;
-
-	asprintf(&realname, "%s%s%s", index(name, '/') ? "" : "/etc/vpnc/", name, add_dot_conf ? ".conf" : "");
+	asprintf(&realname, "%s%s%s", strchr(name, '/') ? "" : "/etc/vpnc/", name, add_dot_conf ? ".conf" : "");
 	return realname;
 }
 

--- a/config.c
+++ b/config.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
+#include <sys/ttydefaults.h>
 
 #include <gcrypt.h>
 

--- a/sysdep.c
+++ b/sysdep.c
@@ -58,13 +58,11 @@
 
 #if defined(__DragonFly__)
 #include <net/tun/if_tun.h>
-#elif defined(__linux__)
-#include <linux/if_tun.h>
 #elif defined(__APPLE__)
 /* no header for tun */
 #elif defined(__CYGWIN__)
 #include "tap-win32.h"
-#else
+#elif !defined(__linux__)
 #include <net/if_tun.h>
 #endif
 

--- a/sysdep.h
+++ b/sysdep.h
@@ -38,11 +38,14 @@ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr);
 
 /***************************************************************************/
 #if defined(__linux__) || defined(__GLIBC__)
+
+#ifdef __GLIBC__
 #include <error.h>
+#define HAVE_ERROR     1
+#endif
 
 #define HAVE_VASPRINTF 1
 #define HAVE_ASPRINTF  1
-#define HAVE_ERROR     1
 #define HAVE_UNSETENV  1
 #define HAVE_SETENV    1
 #endif


### PR DESCRIPTION
Hello,

This set of patches fixes a number of issues found when cross-compiling vpnc, and when building against the uClibc and musl C library.

Except the musl changes which are new, other changes (or similar changes) have been in Buildroot (http://www.buildroot.org) for many years, and it would be great to see them being upstreamed so we can stop maintaining those patches.

Thanks a lot!

Thomas
