### PR TITLE
Fix compilation on Alpine Linux (a musl-based libc distro)

### DIFF
--- a/config.c
+++ b/config.c
@@ -143,7 +143,7 @@ static ssize_t vpnc_getline(char **lineptr, size_t *n, FILE *stream)
 			else
 				break;
 		}
-		if (llen == 0 && c == CEOT)
+		if (llen == 0 && c == 0x04)
 			goto eof_or_ceot;
 		if (c == '\n' || c == '\r')
 			break;

--- a/sysdep.h
+++ b/sysdep.h
@@ -37,12 +37,15 @@ int tun_read(int fd, unsigned char *buf, int len);
 int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr);
 
 /***************************************************************************/
-#if defined(__linux__) || defined(__GLIBC__)
+#if defined(__GLIBC__)
 #include <error.h>
+#define HAVE_ERROR     1
+#endif
 
+/***************************************************************************/
+#if defined(__linux__)
 #define HAVE_VASPRINTF 1
 #define HAVE_ASPRINTF  1
-#define HAVE_ERROR     1
 #define HAVE_UNSETENV  1
 #define HAVE_SETENV    1
 #endif


### PR DESCRIPTION
The musl libc doesn't provide error.h and a corresponding error(...) functions. Luckily, vpnc has one in its source, we just have to use it :) 

Regards,
Stanislav
